### PR TITLE
Fixed core dump on load json + compiler warning

### DIFF
--- a/src/folder.cpp
+++ b/src/folder.cpp
@@ -95,7 +95,7 @@ AbstractFile *Folder::child(int row)
 int Folder::child(AbstractFile *af)
 {
     int ret = -1;
-    for (int i=0; i<tree.size() && ret==-1; i++){
+    for (ulong i=0; i<tree.size() && ret==-1; i++){
         if (tree[i] == af){
             ret = i;
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -167,7 +167,7 @@ void MainWindow::restoreFromJson()
                             tab_idx = tabWidget->addScriptEdit(key);
                             treeModel->addScriptFile(key);
                         }
-                        if (tab_idx)
+                        if (tab_idx>=0)
                             dynamic_cast<CodeEditor*>(tabWidget->widget(tab_idx))->setPlainText(scripts.take(key).toString());
                     }
 


### PR DESCRIPTION
tab_idx could be -1 and cause a segv due to out of bounds container reference.
